### PR TITLE
Create new layer for media keys for planck keymaps

### DIFF
--- a/keyboards/planck/keymaps/rambohippo/keymap.c
+++ b/keyboards/planck/keymaps/rambohippo/keymap.c
@@ -27,14 +27,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  | Shift|
  * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Gui  | Ctrl | Alt  |Numpad|Lower | Space| Enter| Raise| Ctrl | Left | Right| Esc  |
+ * | Gui  | Ctrl | Alt  |Numpad|Lower | Space| Enter| Raise| Media| Left | Right| Esc  |
  * `-----------------------------------------------------------------------------------'
  */
 [_QWERTY] = LAYOUT_planck_grid(
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
     KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
     KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,
-    KC_LGUI, KC_LCTL, KC_LALT, NUMPAD,  TL_LOWR, KC_SPC,  KC_ENT,  TL_UPPR, KC_RCTL, KC_LEFT, KC_RGHT, KC_ESC
+    KC_LGUI, KC_LCTL, KC_LALT, NUMPAD,  TL_LOWR, KC_SPC,  KC_ENT,  TL_UPPR, MEDIA,   KC_LEFT, KC_RGHT, KC_ESC
 ),
 
 /* Lower
@@ -52,12 +52,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    _______,
     WORK_SH, CTAB_BK, CTAB_FW, KC_PGUP, KC_PGDN, ALT_TAB, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, KC_DEL,
     _______, EXDTVAL, _______, KC_TERM, KC_ENT,  KC_BSPC, _______, _______, KC_HOME, KC_END,  _______, _______,
-    KC_F5,   BROWSER, _______, FILES,   _______, _______, _______, _______, _______, _______, _______, _______
+    KC_F5,   BROWSER, _______, FILES,   XXXXXXX, _______, _______, _______, _______, _______, _______, _______
 ),
 
 /* Raise
  * ,-----------------------------------------------------------------------------------.
- * |      |   !  |   @  |   {  |   }  |   |  |      |      |   -  |   \  | MPrev| MNext|
+ * |      |   !  |   @  |   {  |   }  |   |  |      |      |   -  |   \  |      |      |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * | Caps |   #  |   $  |   (  |   )  |   *  |      |   +  |   -  |   _  |      | Del  |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
@@ -67,10 +67,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [_RAISE] = LAYOUT_planck_grid(
-    _______, KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, _______, _______, KC_MINS, KC_BSLS, KC_MPRV, KC_MNXT,
+    _______, KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, _______, _______, KC_MINS, KC_BSLS, _______, _______,
     KC_CAPS, KC_HASH, KC_DLR,  KC_LPRN, KC_RPRN, KC_ASTR, _______, KC_PLUS, KC_EQL,  KC_UNDS, _______, KC_DEL,
     _______, KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_AMPR, _______, KC_QUOT, KC_DQUO, KC_TILD, KC_GRV,  _______,
-    _______, _______, _______, _______, _______, _______, _______, _______, KC_VOLD, KC_VOLU, KC_MPLY, KC_MUTE
+    _______, _______, _______, _______, _______, _______, _______, XXXXXXX, KC_VOLD, KC_VOLU, KC_MPLY, KC_MUTE
 ),
 
 /* NUMPAD
@@ -88,7 +88,25 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, _______, KC_UP,   _______, _______, _______, KC_PEQL, KC_P7,   KC_P8,   KC_P9,   KC_PMNS, _______,
     KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, KC_PAST, KC_P4,   KC_P5,   KC_P6,   KC_PPLS, KC_DEL,
     _______, _______, _______, _______, _______, _______, KC_PSLS, KC_P1,   KC_P2,   KC_P3,   _______, _______,
-    _______, _______, _______, _______, _______, _______, _______, KC_P0,   KC_COMM, KC_PDOT, _______, _______
+    _______, _______, _______, XXXXXXX, _______, _______, _______, KC_P0,   KC_COMM, KC_PDOT, _______, _______
+),
+
+/* Media
+ * ,-----------------------------------------------------------------------------------.
+ * |      |      |      |      |      |      |      |      |      |      |      | Mute |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      | Prev | Next |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      | ---- | VolD | VolU | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_MEDIA] = LAYOUT_planck_grid(
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MUTE,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MPRV, KC_MNXT,
+    _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX, KC_VOLD, KC_VOLU, KC_MPLY
 ),
 
 /* Adjust (Lower + Raise)
@@ -99,14 +117,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * |      |LnWnBk|LnWnFw|WinPre|WinNxt|WinDCL|      |      |      |      |      |      |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |      |      |      |      |      |      |      |      |      |      | Reset|
+ * |      |      |      |      | ---- |      |      | ---- |      |      |      | Reset|
  * `-----------------------------------------------------------------------------------'
  */
 [_ADJUST] = LAYOUT_planck_grid(
     KC_PSCR, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
     _______, _______, _______, CTAB_BK, CTAB_FW, WORK_NW, _______, IDEA_DN, IDEA_UP, _______, _______, KC_F12,
     _______, LN_WNBK, LN_WNFW, WORK_BK, WORK_FW, WORK_CL, _______, _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, QK_BOOT
+    _______, _______, _______, _______, XXXXXXX, _______, _______, XXXXXXX, _______, _______, _______, QK_BOOT
 ),
 
 /* Blank

--- a/keyboards/planck/keymaps/rambohippo/planck6_functions.c
+++ b/keyboards/planck/keymaps/rambohippo/planck6_functions.c
@@ -12,6 +12,7 @@ enum planck_layers {
     _LOWER,
     _RAISE,
     _NUMPAD,
+    _MEDIA,
     _ADJUST
 };
 
@@ -29,6 +30,7 @@ enum planck_keycodes {
 };
 
 #define NUMPAD MO(_NUMPAD)
+#define MEDIA MO(_MEDIA)
 #define LN_DKFW LGUI(LCTL(KC_DOWN))     // Pop OS - Next Workspace
 #define LN_DKBK LGUI(LCTL(KC_UP))       // Pop OS - Previous Workspace
 #define LN_WNFW LGUI(LSFT(KC_DOWN))     // Pop OS - Move window to next workspace

--- a/keyboards/planck/rev7/keymaps/rambohippo/keymap.c
+++ b/keyboards/planck/rev7/keymaps/rambohippo/keymap.c
@@ -29,14 +29,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  | Shift|
  * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Gui  | Ctrl | Alt  |Numpad| Lower| Space| Enter| Raise| Ctrl | Left | Right| Esc  |
+ * | Gui  | Ctrl | Alt  |Numpad| Lower| Space| Enter| Raise| Media| Left | Right| Esc  |
  * `-----------------------------------------------------------------------------------'
  */
 [_QWERTY] = LAYOUT_planck_grid(
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
     KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
     KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,
-    KC_LGUI, KC_LCTL, KC_LALT, NUMPAD,  TL_LOWR, KC_SPC,  KC_ENT,  TL_UPPR, KC_RCTL, KC_LEFT, KC_RGHT, KC_ESC
+    KC_LGUI, KC_LCTL, KC_LALT, NUMPAD,  TL_LOWR, KC_SPC,  KC_ENT,  TL_UPPR, MEDIA,   KC_LEFT, KC_RGHT, KC_ESC
 ),
 
 /* Lower
@@ -54,12 +54,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    _______,
     WORK_SH, CTAB_BK, CTAB_FW, KC_PGUP, KC_PGDN, ALT_TAB, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, KC_DEL,
     _______, EXDTVAL, _______, KC_TERM, KC_ENT,  KC_BSPC, _______, _______, KC_HOME, KC_END,  _______, _______,
-    KC_F5,   BROWSER, _______, FILES,   _______, _______, _______, _______, _______, _______, _______, _______
+    KC_F5,   BROWSER, _______, FILES,   XXXXXXX, _______, _______, _______, _______, _______, _______, _______
 ),
 
 /* Raise
  * ,-----------------------------------------------------------------------------------.
- * |      |   !  |   @  |   {  |   }  |   |  |      |      |   -  |   \  | MPrev| MNext|
+ * |      |   !  |   @  |   {  |   }  |   |  |      |      |   -  |   \  |      |      |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
  * | Caps |   #  |   $  |   (  |   )  |   *  |      |   +  |   -  |   _  |      | Del  |
  * |------+------+------+------+------+------+------+------+------+------+------+------|
@@ -69,10 +69,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------------------------------'
  */
 [_RAISE] = LAYOUT_planck_grid(
-    _______, KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, _______, _______, KC_MINS, KC_BSLS, KC_MPRV, KC_MNXT,
+    _______, KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, _______, _______, KC_MINS, KC_BSLS, _______, _______,
     KC_CAPS, KC_HASH, KC_DLR,  KC_LPRN, KC_RPRN, KC_ASTR, _______, KC_PLUS, KC_EQL,  KC_UNDS, _______, KC_DEL,
     _______, KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_AMPR, _______, KC_QUOT, KC_DQUO, KC_TILD, KC_GRV,  _______,
-    RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, _______, _______, _______, _______, KC_VOLD, KC_VOLU, KC_MPLY, KC_MUTE
+    RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, _______, _______, _______, XXXXXXX, KC_VOLD, KC_VOLU, KC_MPLY, KC_MUTE
 ),
 
 /* NUMPAD
@@ -90,7 +90,25 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, _______, KC_UP,   _______, _______, _______, KC_PEQL, KC_P7,   KC_P8,   KC_P9,   KC_PMNS, KC_NUM,
     KC_DEL,  KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, KC_PAST, KC_P4,   KC_P5,   KC_P6,   KC_PPLS, KC_DEL,
     _______, _______, _______, _______, _______, _______, KC_PSLS, KC_P1,   KC_P2,   KC_P3,   _______, _______,
-    _______, _______, _______, _______, _______, _______, _______, KC_P0,   KC_COMM, KC_PDOT, _______, _______
+    _______, _______, _______, XXXXXXX, _______, _______, _______, KC_P0,   KC_COMM, KC_PDOT, _______, _______
+),
+
+/* Media
+ * ,-----------------------------------------------------------------------------------.
+ * |      |      |      |      |      |      |      |      |      |      |      | Mute |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      |      |      | Prev | Next |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |      |      |      | ---- | VolD | VolU | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_MEDIA] = LAYOUT_planck_grid(
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MUTE,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MPRV, KC_MNXT,
+    _______, _______, _______, _______, _______, _______, _______, _______, XXXXXXX, KC_VOLD, KC_VOLU, KC_MPLY
 ),
 
 /* Adjust (Lower + Raise)
@@ -108,7 +126,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_PSCR, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
     _______, _______, _______, CTAB_BK, CTAB_FW, WORK_NW, _______, IDEA_DN, IDEA_UP, _______, _______, KC_F12,
     _______, LN_WNBK, LN_WNFW, WORK_BK, WORK_FW, WORK_CL, _______, _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, QK_BOOT
+    _______, _______, _______, _______, XXXXXXX, _______, _______, XXXXXXX, _______, _______, _______, QK_BOOT
 )
 
 /* Blank

--- a/keyboards/planck/rev7/keymaps/rambohippo/rambohippo_functions.c
+++ b/keyboards/planck/rev7/keymaps/rambohippo/rambohippo_functions.c
@@ -11,6 +11,7 @@ enum planck_layers {
     _LOWER,
     _RAISE,
     _NUMPAD,
+    _MEDIA,
     _ADJUST
 };
 
@@ -28,6 +29,7 @@ enum planck_keycodes {
 };
 
 #define NUMPAD MO(_NUMPAD)
+#define MEDIA MO(_MEDIA)
 #define LN_DKFW LGUI(LCTL(KC_DOWN))     // Pop OS - Next Workspace
 #define LN_DKBK LGUI(LCTL(KC_UP))       // Pop OS - Previous Workspace
 #define LN_WNFW LGUI(LSFT(KC_DOWN))     // Pop OS - Move window to next workspace


### PR DESCRIPTION
Create new layer for media keys for planck keymaps. The previous solution put media keys over more useful keys, specifically backspace